### PR TITLE
feat: [#4] Determine all images inside a K8s cluster, parse as JSON and send to an endpoint for analysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/mcvs-pr-validation.yml
+++ b/.github/workflows/mcvs-pr-validation.yml
@@ -1,0 +1,19 @@
+---
+name: MCVS-PR-validation-action
+'on':
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+  workflow_call:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  MCVS-PR-validation-action:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - uses: schubergphilis/mcvs-pr-validation-action@v0.1.1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,28 @@
+---
+name: Python application
+on:
+  push:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4.1.0
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3.0.0
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install pip==24.0.0
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          pytest --cov=main test.py --verbose --capture=no --cov-report term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.coverage
+__pycache__

--- a/README.md
+++ b/README.md
@@ -16,8 +16,22 @@ Install [kubectl](https://kubernetes.io/docs/tasks/tools/).
 kubectl get po --all-namespaces
 ```
 
+Create a cronjob:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/application/job/cronjob.yaml
+```
+
 ```bash
 python3 main.py
+```
+
+```bash
+pytest --cov=main test.py --verbose --capture=no --cov-report term-missing
+```
+
+```bash
+python3 mock_server.py
 ```
 
 ```bash

--- a/main.py
+++ b/main.py
@@ -1,6 +1,10 @@
+import json
 import logging
+import requests
 from kubernetes import client, config
 from kubernetes.client.exceptions import ApiException
+import re
+
 
 logger = logging.getLogger(__name__)
 
@@ -18,36 +22,192 @@ def load_kube_config():
         config.load_kube_config()
         logger.info("Kubeconfig loaded successfully")
     except Exception as e:
-        logger.error("Failed to load kubeconfig", exc_info=True)
+        logger.error("Failed to load kubeconfig: '%s'", str(e), exc_info=True)
         return
 
 
-def list_pods():
+def extract_digest(image_reference) -> str:
+    pattern = r"sha256:([a-f0-9]{64})"
+    match = re.search(pattern, image_reference)
+    if match:
+        digest = match.group(1)
+        return digest
+    else:
+        return None
+
+
+def extract_tag(image_reference) -> str:
+    pattern = r":([^:]+)$"
+    match = re.search(pattern, image_reference)
+    if match:
+        tag = match.group(1)
+        return tag
+    else:
+        return None
+
+
+def remove_tag(image_reference) -> str:
+    pattern = r"(:[^:]+)$"
+    clean_reference = re.sub(pattern, "", image_reference)
+    return clean_reference
+
+
+def unique_dicts_by_keys(dicts, keys):
+    if not any(all(k in d for k in keys) for d in dicts):
+        return dicts
+    seen = set()
+    unique = []
+    for d in dicts:
+        composite_key = tuple(d.get(k, None) for k in keys)
+        if composite_key not in seen:
+            seen.add(composite_key)
+            unique.append(d)
+    return unique
+
+
+def list_pods() -> dict:
     v1 = client.CoreV1Api()
+    dict_list = []
     try:
         logger.info("Listing pods in all namespaces")
         ret = v1.list_pod_for_all_namespaces()
         for pod in ret.items:
-            logger.info(
+            logger.debug(
                 f"Namespace: {pod.metadata.namespace}, Pod name: {pod.metadata.name}"
             )
             for container_status in pod.status.container_statuses:
                 image = container_status.image
                 image_id = container_status.image_id
-                logger.info(
+                logger.debug(
                     f"Container name: {container_status.name}, Container image: {image}, Image ID: {image_id}"
                 )
+                tag = extract_tag(image)
+                image = remove_tag(image)
+                image_id = extract_digest(image_id)
+                new_dict = {"image": image, "digest": image_id, "tag": tag}
+                dict_list.append(new_dict)
     except ApiException as e:
         logger.error(
-            "Exception when calling CoreV1Api->list_pod_for_all_namespaces",
+            "Exception when calling CoreV1Api->list_pod_for_all_namespaces: '%s'",
+            str(e),
             exc_info=True,
         )
+    logger.info("Unique container images and their digests:")
+    return dict_list
+
+
+def list_cron_jobs() -> dict:
+    batch_v1 = client.BatchV1Api()
+    core_v1 = client.CoreV1Api()
+    dict_list = []
+    try:
+        logger.info("Listing Jobs in all namespaces")
+        jobs = batch_v1.list_job_for_all_namespaces()
+        for job in jobs.items:
+            logger.debug(
+                f"Namespace: {job.metadata.namespace}, Job name: {job.metadata.name}"
+            )
+            pod_template = job.spec.template
+            for container in pod_template.spec.containers:
+                logger.debug(
+                    f"  Container name: {container.name}, Container image: {container.image}"
+                )
+                job_selector = f"job-name={job.metadata.name}"
+                pods = core_v1.list_namespaced_pod(
+                    namespace=job.metadata.namespace,
+                    label_selector=job_selector,
+                )
+                for pod in pods.items:
+                    for container_status in pod.status.container_statuses:
+                        if container_status.name == container.name:
+                            image = container_status.image
+                            image_id = container_status.image_id
+                            logger.debug(
+                                f"    Pod name: {pod.metadata.name}, Image digest: {image_id}"
+                            )
+                            tag = extract_tag(image)
+                            image = remove_tag(image)
+                            image_id = extract_digest(image_id)
+                            new_dict = {
+                                "image": image,
+                                "digest": image_id,
+                                "tag": tag,
+                            }
+                            dict_list.append(new_dict)
+    except ApiException as e:
+        logger.error(
+            "Exception when calling BatchV1beta1Api->list_cron_job_for_all_namespaces: '%s'",
+            str(e),
+            exc_info=True,
+        )
+    logger.info("Unique container images and their digests:")
+    return dict_list
+
+
+def construct_json(images: dict) -> str:
+    json_data = json.dumps(
+        [
+            {
+                "name": item.get("image"),
+                "digestSha256": item.get("digest"),
+                "tag": item.get("tag"),
+                "account": {
+                    "environment": "dev",
+                    "id": 123,
+                    "name": "hello",
+                    "owner": "world",
+                    "project": "some-project",
+                    "provider": "aws",
+                    "team": "some-team",
+                },
+            }
+            for item in images
+        ],
+        indent=2,
+    )
+    logger.debug("JSON data: " + json_data)
+    return json_data
+
+
+def send_json_to_endpoint(json_string):
+    url = "http://localhost:5000/endpoint"
+
+    try:
+        response = requests.post(
+            url, data=json_string, headers={"Content-Type": "application/json"}
+        )
+        response.raise_for_status()  # Raise an HTTPError for bad responses (4xx and 5xx)
+
+        # Log success
+        logger.info("Request was successful.")
+        logger.info("Response JSON: %s", response.json())
+    except requests.exceptions.HTTPError as http_err:
+        if response.status_code == 500:
+            logger.error("Internal Server Error occurred: %s", http_err)
+        else:
+            logger.error("HTTP error occurred: %s", http_err)
+    except requests.exceptions.ConnectionError as conn_err:
+        logger.error("Error connecting to the endpoint: %s", conn_err)
+    except requests.exceptions.Timeout as timeout_err:
+        logger.error("Request timed out: %s", timeout_err)
+    except requests.exceptions.RequestException as req_err:
+        logger.error("An error occurred while sending the request: %s", req_err)
+    except Exception as e:
+        logger.error("An unexpected error occurred: %s", e)
 
 
 def main():
     setup_logging()
     load_kube_config()
-    list_pods()
+    pod_images = list_pods()
+    cron_job_images = list_cron_jobs()
+    pod_images.extend(cron_job_images)
+    unique_pod_images = unique_dicts_by_keys(
+        pod_images, ["image", "digest", "tag"]
+    )
+    json_string = construct_json(unique_pod_images)
+    print(json_string)
+    send_json_to_endpoint(json_string)
 
 
 if __name__ == "__main__":

--- a/mock_server.py
+++ b/mock_server.py
@@ -1,0 +1,14 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+
+@app.route("/endpoint", methods=["POST"])
+def handle_post():
+    data = request.json
+    print("Received JSON data:", data)  # Print the received JSON data
+    return jsonify({"status": "success", "received_data": data}), 200
+
+
+if __name__ == "__main__":
+    app.run(port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+flake8==6.0.0
+kubernetes==30.1.0
+pytest==7.2.1
+pytest-cov==4.1.0
+requests==2.29.0
+requests-mock==1.12.1

--- a/test.py
+++ b/test.py
@@ -1,0 +1,652 @@
+import json
+import logging
+import main
+import requests
+import requests_mock
+import unittest
+from unittest.mock import patch, MagicMock
+from main import (
+    construct_json,
+    extract_digest,
+    extract_tag,
+    list_cron_jobs,
+    list_pods,
+    load_kube_config,
+    remove_tag,
+    send_json_to_endpoint,
+    setup_logging,
+    unique_dicts_by_keys,
+)
+from kubernetes.client.rest import ApiException
+
+
+def test_valid_digest():
+    image_reference = "docker.io/library/busybox@sha256:141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47"
+    assert (
+        extract_digest(image_reference)
+        == "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47"
+    )
+
+
+def test_no_digest():
+    image_reference = "docker.io/library/busybox:latest"
+    assert extract_digest(image_reference) is None
+
+
+def test_invalid_format():
+    image_reference = "docker.io/library/busybox@sha1:12345"
+    assert extract_digest(image_reference) is None
+
+
+def test_empty_input_digest_to_be_extracted():
+    image_reference = ""
+    assert extract_digest(image_reference) is None
+
+
+def test_no_sha256_prefix():
+    image_reference = "docker.io/library/busybox@abc123"
+    assert extract_digest(image_reference) is None
+
+
+def test_valid_tag():
+    image_reference = "docker.io/library/busybox:latest"
+    assert extract_tag(image_reference) == "latest"
+
+
+def test_no_tag_to_be_extracted():
+    image_reference = "docker.io/library/busybox"
+    assert extract_tag(image_reference) is None
+
+
+def test_invalid_format_tag():
+    image_reference = "docker.io/library/busybox:invalid@format"
+    assert extract_tag(image_reference) == "invalid@format"
+
+
+def test_empty_input_tag_to_be_extracted():
+    image_reference = ""
+    assert extract_tag(image_reference) is None
+
+
+def test_no_colon():
+    image_reference = "docker.io/library/busybox"
+    assert extract_tag(image_reference) is None
+
+
+def test_remove_valid_tag():
+    image_reference = "docker.io/library/busybox:latest"
+    assert remove_tag(image_reference) == "docker.io/library/busybox"
+
+
+def test_remove_tag_with_version():
+    image_reference = "docker.io/library/busybox:v1.0"
+    assert remove_tag(image_reference) == "docker.io/library/busybox"
+
+
+def test_no_tag():
+    image_reference = "docker.io/library/busybox"
+    assert remove_tag(image_reference) == "docker.io/library/busybox"
+
+
+def test_empty_input():
+    image_reference = ""
+    assert remove_tag(image_reference) == ""
+
+
+def test_tag_with_colon():
+    image_reference = "docker.io/library/busybox:latest:extra"
+    assert remove_tag(image_reference) == "docker.io/library/busybox:latest"
+
+
+def test_unique_dicts():
+    dicts = [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bob"},
+        {"id": 1, "name": "Alice"},
+        {"id": 3, "name": "Charlie"},
+    ]
+    keys = ["id"]
+    expected = [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bob"},
+        {"id": 3, "name": "Charlie"},
+    ]
+    assert unique_dicts_by_keys(dicts, keys) == expected
+
+
+def test_unique_dicts_multiple_keys():
+    dicts = [
+        {"id": 1, "name": "Alice", "age": 30},
+        {"id": 1, "name": "Alice", "age": 25},
+        {"id": 2, "name": "Bob", "age": 30},
+        {"id": 2, "name": "Bob", "age": 35},
+    ]
+    keys = ["id", "name"]
+    expected = [
+        {"id": 1, "name": "Alice", "age": 30},
+        {"id": 2, "name": "Bob", "age": 30},
+    ]
+    assert unique_dicts_by_keys(dicts, keys) == expected
+
+
+def test_no_duplicates():
+    dicts = [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+    keys = ["id"]
+    expected = [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+    assert unique_dicts_by_keys(dicts, keys) == expected
+
+
+def test_empty_list():
+    dicts = []
+    keys = ["id"]
+    assert unique_dicts_by_keys(dicts, keys) == []
+
+
+def test_empty_dicts():
+    dicts = [{}, {}, {}]
+    keys = []
+    expected = [{}]
+    assert unique_dicts_by_keys(dicts, keys) == expected
+
+
+def test_non_existent_key():
+    dicts = [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+    keys = ["non_existent_key"]
+    expected = [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+    assert unique_dicts_by_keys(dicts, keys) == expected
+
+
+def test_construct_json_single_entry():
+    images = [
+        {
+            "image": "docker.io/library/busybox",
+            "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+            "tag": "1.28",
+        }
+    ]
+    expected_json = json.dumps(
+        [
+            {
+                "name": "docker.io/library/busybox",
+                "digestSha256": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+                "tag": "1.28",
+                "account": {
+                    "environment": "dev",
+                    "id": 123,
+                    "name": "hello",
+                    "owner": "world",
+                    "project": "some-project",
+                    "provider": "aws",
+                    "team": "some-team",
+                },
+            }
+        ],
+        indent=2,
+    )
+    result_json = construct_json(images)
+    assert result_json == expected_json
+
+
+def test_construct_json_multiple_entries():
+    images = [
+        {
+            "image": "docker.io/library/busybox",
+            "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+            "tag": "1.28",
+        },
+        {
+            "image": "docker.io/library/alpine",
+            "digest": "b1f2a2b8c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0",
+            "tag": "3.12",
+        },
+    ]
+    expected_json = json.dumps(
+        [
+            {
+                "name": "docker.io/library/busybox",
+                "digestSha256": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+                "tag": "1.28",
+                "account": {
+                    "environment": "dev",
+                    "id": 123,
+                    "name": "hello",
+                    "owner": "world",
+                    "project": "some-project",
+                    "provider": "aws",
+                    "team": "some-team",
+                },
+            },
+            {
+                "name": "docker.io/library/alpine",
+                "digestSha256": "b1f2a2b8c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0",
+                "tag": "3.12",
+                "account": {
+                    "environment": "dev",
+                    "id": 123,
+                    "name": "hello",
+                    "owner": "world",
+                    "project": "some-project",
+                    "provider": "aws",
+                    "team": "some-team",
+                },
+            },
+        ],
+        indent=2,
+    )
+    result_json = construct_json(images)
+    assert result_json == expected_json
+
+
+def test_construct_json_empty_list():
+    images = []
+    expected_json = json.dumps([], indent=2)
+    result_json = construct_json(images)
+    assert result_json == expected_json
+
+
+def test_construct_json_missing_keys():
+    images = [
+        {
+            "image": "docker.io/library/busybox"
+            # 'digest' and 'tag' are missing
+        }
+    ]
+    expected_json = json.dumps(
+        [
+            {
+                "name": "docker.io/library/busybox",
+                "digestSha256": None,  # None should be reflected as null in JSON
+                "tag": None,  # None should be reflected as null in JSON
+                "account": {
+                    "environment": "dev",
+                    "id": 123,
+                    "name": "hello",
+                    "owner": "world",
+                    "project": "some-project",
+                    "provider": "aws",
+                    "team": "some-team",
+                },
+            }
+        ],
+        indent=2,
+    )
+    result_json = construct_json(images)
+    assert result_json == expected_json
+
+
+class TestListPods(unittest.TestCase):
+    @patch("main.client.CoreV1Api")
+    def test_list_pods(self, mock_core_v1_api):
+        # Create mock objects
+        mock_pod = MagicMock()
+        mock_pod.metadata.namespace = "default"
+        mock_pod.metadata.name = "test-pod"
+
+        mock_container_status = MagicMock()
+        mock_container_status.name = "test-container"
+        mock_container_status.image = "docker.io/library/busybox:1.28"
+        digest = (
+            "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47"
+        )
+        mock_container_status.image_id = (
+            "docker.io/library/busybox@sha256:" + digest
+        )
+        mock_pod.status.container_statuses = [mock_container_status]
+
+        mock_core_v1_api.return_value.list_pod_for_all_namespaces.return_value.items = [
+            mock_pod
+        ]
+
+        expected_output = [
+            {
+                "image": "docker.io/library/busybox",
+                "digest": digest,
+                "tag": "1.28",
+            }
+        ]
+
+        result = list_pods()
+
+        self.assertEqual(result, expected_output)
+
+    @patch("main.client.CoreV1Api")
+    def test_list_pods_api_exception(self, mock_core_v1_api):
+        # Mock the CoreV1Api to raise an ApiException
+        mock_core_v1_api.return_value.list_pod_for_all_namespaces.side_effect = ApiException(
+            "API Exception"
+        )
+
+        # Check if the function handles the exception gracefully and returns an empty list
+        result = list_pods()
+
+        self.assertEqual(result, [])
+
+
+class TestListCronJobs(unittest.TestCase):
+    @patch("main.client.CoreV1Api")
+    @patch("main.client.BatchV1Api")
+    def test_list_cron_jobs(self, mock_batch_v1_api, mock_core_v1_api):
+        # Create mock objects for the job and pod template
+        mock_job = MagicMock()
+        mock_job.metadata.namespace = "default"
+        mock_job.metadata.name = "test-job"
+
+        mock_container = MagicMock()
+        mock_container.name = "test-container"
+        mock_container.image = "docker.io/library/busybox:1.28"
+
+        mock_job.spec.template.spec.containers = [mock_container]
+
+        # Mocking the BatchV1Api response for jobs
+        mock_batch_v1_api.return_value.list_job_for_all_namespaces.return_value.items = [
+            mock_job
+        ]
+
+        # Create a mock pod object with container statuses
+        mock_pod = MagicMock()
+        mock_pod.metadata.name = "test-pod"
+
+        mock_container_status = MagicMock()
+        mock_container_status.name = "test-container"
+        mock_container_status.image = "docker.io/library/busybox:1.28"
+        digest = (
+            "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47"
+        )
+        mock_container_status.image_id = (
+            "docker.io/library/busybox@sha256:" + digest
+        )
+
+        mock_pod.status.container_statuses = [mock_container_status]
+
+        # Mocking the CoreV1Api response for pods
+        mock_core_v1_api.return_value.list_namespaced_pod.return_value.items = [
+            mock_pod
+        ]
+
+        expected_output = [
+            {
+                "image": "docker.io/library/busybox",
+                "digest": digest,
+                "tag": "1.28",
+            }
+        ]
+
+        result = list_cron_jobs()
+
+        self.assertEqual(result, expected_output)
+
+    @patch("main.client.CoreV1Api")
+    @patch("main.client.BatchV1Api")
+    def test_list_cron_jobs_api_exception(
+        self, mock_batch_v1_api, mock_core_v1_api
+    ):
+        # Mock the BatchV1Api to raise an ApiException
+        mock_batch_v1_api.return_value.list_job_for_all_namespaces.side_effect = ApiException(
+            "API Exception"
+        )
+
+        # Check if the function handles the exception gracefully and returns an empty list
+        result = list_cron_jobs()
+
+        self.assertEqual(result, [])
+
+
+class TestLoadKubeConfig(unittest.TestCase):
+    @patch("main.config.load_kube_config")
+    @patch("main.logger")  # Patch the logger object
+    def test_load_kube_config_success(self, mock_logger, mock_load_kube_config):
+        # Mock the load_kube_config method to succeed
+        mock_load_kube_config.return_value = None
+
+        # Call the function
+        load_kube_config()
+
+        # Check that the logger info method was called with the success message
+        mock_logger.info.assert_called_with("Kubeconfig loaded successfully")
+
+    @patch("main.config.load_kube_config")
+    @patch("main.logger")  # Patch the logger object
+    def test_load_kube_config_failure(self, mock_logger, mock_load_kube_config):
+        # Mock the load_kube_config method to raise an exception
+        mock_load_kube_config.side_effect = Exception("Load kubeconfig failed")
+
+        # Call the function
+        load_kube_config()
+
+        # Check that the logger error method was called with the failure message
+        mock_logger.error.assert_called_with(
+            "Failed to load kubeconfig: '%s'",
+            "Load kubeconfig failed",
+            exc_info=True,
+        )
+
+
+class TestSetupLogging(unittest.TestCase):
+    @patch("logging.basicConfig")
+    def test_setup_logging(self, mock_basic_config):
+        # Call the setup_logging function
+        setup_logging()
+
+        # Extract the actual call parameters
+        args, kwargs = mock_basic_config.call_args
+
+        # Check if the logging level, format, and handlers are as expected
+        self.assertEqual(kwargs.get("level"), logging.INFO)
+        self.assertEqual(
+            kwargs.get("format"),
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+
+        # Check if handlers list contains a StreamHandler
+        handlers = kwargs.get("handlers", [])
+        self.assertEqual(len(handlers), 1)
+        self.assertIsInstance(handlers[0], logging.StreamHandler)
+
+
+class TestMainFunction(unittest.TestCase):
+    @patch("main.send_json_to_endpoint")
+    @patch("main.setup_logging")
+    @patch("main.load_kube_config")
+    @patch("main.list_pods")
+    @patch("main.list_cron_jobs")
+    @patch("main.unique_dicts_by_keys")
+    @patch("main.construct_json")
+    def test_main(
+        self,
+        mock_construct_json,
+        mock_unique_dicts_by_keys,
+        mock_list_cron_jobs,
+        mock_list_pods,
+        mock_load_kube_config,
+        mock_setup_logging,
+        mock_send_json_to_endpoint,
+    ):
+        # Mock return values for functions called in main()
+        mock_list_pods.return_value = [
+            {
+                "image": "docker.io/library/busybox",
+                "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+                "tag": "1.28",
+            }
+        ]
+        mock_list_cron_jobs.return_value = [
+            {
+                "image": "docker.io/library/busybox",
+                "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+                "tag": "1.28",
+            }
+        ]
+        mock_unique_dicts_by_keys.return_value = [
+            {
+                "image": "docker.io/library/busybox",
+                "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+                "tag": "1.28",
+            }
+        ]
+        mock_construct_json.return_value = """
+{
+  "image": "docker.io/library/busybox",
+  "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+  "tag": "1.28"
+}
+"""
+
+        # Call the main function
+        main.main()
+
+        # Verify that setup_logging was called
+        mock_setup_logging.assert_called_once()
+
+        # Verify that load_kube_config was called
+        mock_load_kube_config.assert_called_once()
+
+        # Verify that list_pods was called
+        mock_list_pods.assert_called_once()
+
+        # Verify that list_cron_jobs was called
+        mock_list_cron_jobs.assert_called_once()
+
+        # Verify that unique_dicts_by_keys was called with the expected arguments
+        mock_unique_dicts_by_keys.assert_called_once_with(
+            [
+                {
+                    "image": "docker.io/library/busybox",
+                    "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+                    "tag": "1.28",
+                },
+                {
+                    "image": "docker.io/library/busybox",
+                    "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+                    "tag": "1.28",
+                },
+            ],
+            ["image", "digest", "tag"],
+        )
+
+        # Verify that construct_json was called with the expected arguments
+        mock_construct_json.assert_called_once_with(
+            [
+                {
+                    "image": "docker.io/library/busybox",
+                    "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+                    "tag": "1.28",
+                }
+            ]
+        )
+
+        mock_send_json_to_endpoint.assert_called_once_with(
+            mock_construct_json.return_value
+        )
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+
+class TestSendJsonToEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        # Setup logging
+        setup_logging()
+
+    @requests_mock.Mocker()
+    def test_send_json_success(self, mock):
+        url = "http://localhost:5000/endpoint"
+        mock.post(url, json={"message": "success"}, status_code=200)
+
+        with self.assertLogs(logger, level="INFO") as log:
+            send_json_to_endpoint('{"key": "value"}')
+
+        # Check that the request was made with correct parameters
+        self.assertTrue(mock.called)
+        request = mock.request_history[0]
+        self.assertEqual(request.method, "POST")
+        self.assertEqual(request.url, url)
+        self.assertEqual(request.json(), {"key": "value"})
+
+        # Check the logs
+        self.assertIn("Request was successful.", log.output[0])
+        self.assertIn("Response JSON: {'message': 'success'}", log.output[1])
+
+    @requests_mock.Mocker()
+    def test_send_json_http_error_400(self, mock):
+        url = "http://localhost:5000/endpoint"
+        mock.post(url, status_code=400)
+
+        with self.assertLogs(logger, level="ERROR") as log:
+            send_json_to_endpoint('{"key": "value"}')
+
+        # Check the logs for error message
+        self.assertIn("HTTP error occurred:", log.output[0])
+
+    @requests_mock.Mocker()
+    def test_send_json_http_error_500(self, mock):
+        url = "http://localhost:5000/endpoint"
+        mock.post(url, status_code=500)
+
+        with self.assertLogs(logger, level="ERROR") as log:
+            send_json_to_endpoint('{"key": "value"}')
+
+        # Check the logs for error message
+        self.assertIn("Internal Server Error occurred:", log.output[0])
+
+    @requests_mock.Mocker()
+    def test_send_json_connection_error(self, mock):
+        url = "http://localhost:5000/endpoint"
+        mock.register_uri(
+            "POST",
+            url,
+            exc=requests.exceptions.ConnectionError("Connection error"),
+        )
+
+        with self.assertLogs(logger, level="ERROR") as log:
+            send_json_to_endpoint('{"key": "value"}')
+
+        # Check the logs for error message
+        self.assertIn(
+            "Error connecting to the endpoint: Connection error", log.output[0]
+        )
+
+    @requests_mock.Mocker()
+    def test_send_json_timeout(self, mock):
+        url = "http://localhost:5000/endpoint"
+        mock.register_uri(
+            "POST", url, exc=requests.exceptions.Timeout("Timeout error")
+        )
+
+        with self.assertLogs(logger, level="ERROR") as log:
+            send_json_to_endpoint('{"key": "value"}')
+
+        # Check the logs for error message
+        self.assertIn("Request timed out: Timeout error", log.output[0])
+
+    @requests_mock.Mocker()
+    def test_send_json_request_exception(self, mock):
+        url = "http://localhost:5000/endpoint"
+        mock.register_uri(
+            "POST",
+            url,
+            exc=requests.exceptions.RequestException("Request exception"),
+        )
+
+        with self.assertLogs(logger, level="ERROR") as log:
+            send_json_to_endpoint('{"key": "value"}')
+
+        # Check the logs for error message
+        self.assertIn(
+            "An error occurred while sending the request: Request exception",
+            log.output[0],
+        )
+
+    @requests_mock.Mocker()
+    def test_send_json_unexpected_exception(self, mock):
+        url = "http://localhost:5000/endpoint"
+        mock.register_uri("POST", url, exc=Exception("Unexpected error"))
+
+        with self.assertLogs(logger, level="ERROR") as log:
+            send_json_to_endpoint('{"key": "value"}')
+
+        # Check the logs for error message
+        self.assertIn(
+            "An unexpected error occurred: Unexpected error", log.output[0]
+        )

--- a/test/testdata/images.json
+++ b/test/testdata/images.json
@@ -1,0 +1,77 @@
+[
+  {
+    "image": "docker.io/library/busybox",
+    "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+    "tag": "1.28"
+  },
+  {
+    "image": "docker.io/library/busybox",
+    "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+    "tag": "1.28"
+  },
+  {
+    "image": "docker.io/library/busybox",
+    "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+    "tag": "1.28"
+  },
+  {
+    "image": "registry.k8s.io/coredns/coredns",
+    "digest": "cbb01a7bd410dc08ba382018ab909a674fb0e48687f0c00797ed5bc34fcc6bb4",
+    "tag": "v1.11.1"
+  },
+  {
+    "image": "registry.k8s.io/coredns/coredns",
+    "digest": "cbb01a7bd410dc08ba382018ab909a674fb0e48687f0c00797ed5bc34fcc6bb4",
+    "tag": "v1.11.1"
+  },
+  {
+    "image": "registry.k8s.io/etcd",
+    "digest": "3861cfcd7c04ccac1f062788eca39487248527ef0c0cfd477a83d7691a75a899",
+    "tag": "3.5.12-0"
+  },
+  {
+    "image": "docker.io/kindest/kindnetd",
+    "digest": "ac1c61439df4625ba53a9ceaccb5eb07a830bdf942cc1c60535a4dd7e763d55f",
+    "tag": "v20240513-cd2ac642"
+  },
+  {
+    "image": "registry.k8s.io/kube-apiserver-amd64",
+    "digest": "595bbac7dd5875ee5a7c2c78763571b84e8666066190b815d4ffc9f91c5963ef",
+    "tag": "v1.30.2"
+  },
+  {
+    "image": "registry.k8s.io/kube-controller-manager-amd64",
+    "digest": "d129df42264227336850a3ecd99a09b4af9c16f04e0d95b113379859b9f8d322",
+    "tag": "v1.30.2"
+  },
+  {
+    "image": "registry.k8s.io/kube-proxy-amd64",
+    "digest": "2f082372b751058f581b5a2163e0b8d3058ff4a8d5b0b97b8e145e6f87882b16",
+    "tag": "v1.30.2"
+  },
+  {
+    "image": "registry.k8s.io/kube-scheduler-amd64",
+    "digest": "16af68c80df597a2c5aed3b6fef25bf08ca4ee63aaac95e9c89b5b7369c1f991",
+    "tag": "v1.30.2"
+  },
+  {
+    "image": "docker.io/kindest/local-path-provisioner",
+    "digest": "f250a35425c92d758d72d00d587ba0892e952fb7151c9cac6f7791409f376928",
+    "tag": "v20240513-b9bba138"
+  },
+  {
+    "image": "docker.io/library/busybox",
+    "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+    "tag": "1.28"
+  },
+  {
+    "image": "docker.io/library/busybox",
+    "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+    "tag": "1.28"
+  },
+  {
+    "image": "docker.io/library/busybox",
+    "digest": "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47",
+    "tag": "1.28"
+  }
+]


### PR DESCRIPTION
This PR ensures that all images that are in use by pods and cronjobs in a K8s cluster can be determined, parsed as JSON and send to an endpoint for further analysis.